### PR TITLE
New Boards

### DIFF
--- a/boards/dadamachines-automat/board_config.h
+++ b/boards/dadamachines-automat/board_config.h
@@ -1,0 +1,20 @@
+#ifndef BOARD_CONFIG_H
+#define BOARD_CONFIG_H
+
+#define __SAMD21G18A__ 1
+
+#define VENDOR_NAME "dadamachines"
+#define PRODUCT_NAME "automat"
+#define VOLUME_LABEL "AUTOMAT"
+#define INDEX_URL "http://dadamachines.com/"
+#define BOARD_ID "SAMD21G18A-dadamachines-automat-v0"
+
+#define USB_VID 0x16D0
+#define USB_PID 0x0CDA
+#define USB_POWER_MA 20
+
+#define LED_PIN PIN_PA17
+//#define LED_TX_PIN PIN_PA27
+//#define LED_RX_PIN PIN_PB03
+
+#endif

--- a/boards/eitech-robotics/board_config.h
+++ b/boards/eitech-robotics/board_config.h
@@ -1,0 +1,17 @@
+#ifndef BOARD_CONFIG_H
+#define BOARD_CONFIG_H
+
+#define __SAMD21G18A__ 1
+
+#define VENDOR_NAME "Eitech"
+#define PRODUCT_NAME "Robotics"
+#define VOLUME_LABEL "ROBOTICS"
+#define INDEX_URL "http://www.eitech.de/"
+#define BOARD_ID "SAMD21G18A-Eitech-Robotics-v0"
+
+#define USB_VID 0x1D50
+#define USB_PID 0x6110 // PID from Openmoko Project
+
+#define LED_PIN PIN_PA30
+
+#endif

--- a/boards/sensebox-mcu/board_config.h
+++ b/boards/sensebox-mcu/board_config.h
@@ -1,0 +1,18 @@
+#ifndef BOARD_CONFIG_H
+#define BOARD_CONFIG_H
+
+#define __SAMD21G18A__ 1
+
+#define VENDOR_NAME "eduSense"
+#define PRODUCT_NAME "senseBox MCU"
+#define VOLUME_LABEL "SENSEBOX"
+#define INDEX_URL "http://www.sensebox.de"
+#define BOARD_ID "SAMD21G18A-senseBox-MCU-v0"
+
+#define USB_VID 0x04D8
+#define USB_PID 0xEF66 // PID sublicensed from Microchip
+#define USB_POWER_MA 20
+
+#define LED_PIN PIN_PA27 // red LED
+
+#endif

--- a/boards/wattuino-rc/board_config.h
+++ b/boards/wattuino-rc/board_config.h
@@ -1,0 +1,17 @@
+#ifndef BOARD_CONFIG_H
+#define BOARD_CONFIG_H
+
+#define __SAMD21G18A__ 1
+
+#define VENDOR_NAME "Watterott electronic"
+#define PRODUCT_NAME "Wattuino RC"
+#define VOLUME_LABEL "RCBOOT"
+#define INDEX_URL "http://www.watterott.com"
+#define BOARD_ID "SAMD21G18A-Wattuino-RC-v0"
+
+#define USB_VID 0x1D50
+#define USB_PID 0x6112 // PID from Openmoko Project
+
+#define LED_PIN PIN_PA30
+
+#endif


### PR DESCRIPTION
This PR adds support for the following SAMD21 or SAMW25 based boards:
* [dadamachines automat](https://dadamachines.com/)
* [senseBox MCU](https://github.com/watterott/senseBox-MCU)
* [Eitech Robotics](https://github.com/watterott/Eitech-Robotics)
* [Wattuino RC](https://github.com/watterott/Wattuino)

All boards are open-hardware, but currently not all design files are released.
